### PR TITLE
reverse-string: Refactor analyzer to work with lints instead of prepared ASTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ version = "0.3.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "rust-analyzer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-analyzer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 description = "Exercism's automated analyzer for the Rust track."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ description = "Exercism's automated analyzer for the Rust track."
 [dependencies]
 failure = "0.1.5"
 serde_json = "1.0.39"
-lazy_static = "1.3.0"
 
 [dependencies.serde]
 version = "1.0.91"

--- a/snippets/reverse-string/disapprove_with_solution_not_found/src/lib.rs
+++ b/snippets/reverse-string/disapprove_with_solution_not_found/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("Test");
+}

--- a/src/analyzers/output.rs
+++ b/src/analyzers/output.rs
@@ -21,8 +21,8 @@ pub enum AnalysisStatus {
 /// The result of the exercise analysis.
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct AnalysisOutput {
-    status: AnalysisStatus,
-    comments: Vec<String>,
+    pub status: AnalysisStatus,
+    pub comments: Vec<String>,
 }
 
 impl AnalysisOutput {

--- a/src/analyzers/reverse_string/README.md
+++ b/src/analyzers/reverse_string/README.md
@@ -57,7 +57,13 @@ pub fn reverse(input: &str) -> String {
 
 ## disapprove
 
-In development
+If the solution does not contain a properly defined `reverse` function it will be disapproved with the `eust.reverse_string.solution_function_not_found` comment:
+
+```rust
+fn main() {
+    println!("Test");
+}
+```
 
 ## refer_to_mentor
 

--- a/src/analyzers/reverse_string/comments.rs
+++ b/src/analyzers/reverse_string/comments.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Display};
 pub enum ReverseStringComment {
     SuggestRemovingExternCrate,
     SuggestDoingBonusTest,
+    SolutionFunctionNotFound,
 }
 
 impl Display for ReverseStringComment {
@@ -17,6 +18,7 @@ impl Display for ReverseStringComment {
             match self {
                 SuggestRemovingExternCrate => "rust.reverse_string.suggest_removing_extern_crate",
                 SuggestDoingBonusTest => "rust.reverse_string.suggest_doing_bonus_test",
+                SolutionFunctionNotFound => "rust.reverse_string.solution_function_not_found",
             }
         )
     }

--- a/src/analyzers/reverse_string/lints.rs
+++ b/src/analyzers/reverse_string/lints.rs
@@ -1,0 +1,216 @@
+//! #lints
+//! This module contains lints that are used on a "reverse-string" solution.
+//! Each lint performs a single check on an input solution AST and, depending on the check result,
+//! modifies the output analysis.
+//! Each lint assumes that the solution contains a properly declared "reverse" function.
+
+use crate::{
+    analyzers::{
+        output::{AnalysisOutput, AnalysisStatus},
+        reverse_string::comments::ReverseStringComment,
+    },
+    Result,
+};
+
+use syn::File;
+
+pub static REVERSE_STRING_LINTS: &'static [fn(&File, &mut AnalysisOutput) -> Result<()>] = &[
+    check_for_extern_crate,
+    check_for_standard_solution,
+    check_for_optimal_solution,
+];
+
+fn check_for_extern_crate(ast: &File, output: &mut AnalysisOutput) -> Result<()> {
+    let has_extern = ast.items.iter().any(|item| {
+        if let syn::Item::ExternCrate(_) = item {
+            true
+        } else {
+            false
+        }
+    });
+    if has_extern {
+        output
+            .comments
+            .push(ReverseStringComment::SuggestRemovingExternCrate.to_string());
+    }
+    Ok(())
+}
+
+fn check_for_standard_solution(ast: &File, output: &mut AnalysisOutput) -> Result<()> {
+    let reverse_fn = if let Some(syn::Item::Fn(func)) = ast.items.iter().find(|item| {
+        if let syn::Item::Fn(item_fn) = item {
+            item_fn.ident == "reverse"
+        } else {
+            false
+        }
+    }) {
+        func
+    } else {
+        // We can use the unreachable!, since we have already check for
+        // the "reverse" function existence at the analyze function.
+        unreachable!();
+    };
+    // Check if the "reverse" function contains the "input.chars().rev().collect()"
+    // solution
+    let has_standard_solution = reverse_fn.block.stmts.iter().any(|stmt| {
+        if let syn::Stmt::Expr(syn::Expr::MethodCall(syn::ExprMethodCall {
+            method,
+            receiver,
+            ..
+        })) = stmt
+        {
+            if method != "collect" {
+                false
+            } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
+                method, receiver, ..
+            }) = receiver.as_ref()
+            {
+                if method != "rev" {
+                    false
+                } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
+                    method, receiver, ..
+                }) = receiver.as_ref()
+                {
+                    if method != "chars" {
+                        false
+                    } else if let syn::Expr::Path(syn::ExprPath { path, .. }) = receiver.as_ref() {
+                        if let Some(syn::punctuated::Pair::End(path_segment)) =
+                            path.segments.first()
+                        {
+                            if let Some(syn::punctuated::Pair::End(syn::FnArg::Captured(
+                                syn::ArgCaptured {
+                                    pat: syn::Pat::Ident(syn::PatIdent { ident, .. }),
+                                    ..
+                                },
+                            ))) = reverse_fn.decl.inputs.first()
+                            {
+                                *ident == path_segment.ident
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    });
+    if has_standard_solution {
+        output.status = AnalysisStatus::Approve;
+        output
+            .comments
+            .push(ReverseStringComment::SuggestDoingBonusTest.to_string())
+    }
+    Ok(())
+}
+
+fn check_for_optimal_solution(ast: &File, output: &mut AnalysisOutput) -> Result<()> {
+    let reverse_fn = if let Some(syn::Item::Fn(func)) = ast.items.iter().find(|item| {
+        if let syn::Item::Fn(item_fn) = item {
+            item_fn.ident == "reverse"
+        } else {
+            false
+        }
+    }) {
+        func
+    } else {
+        // We can use the unreachable!, since we have already check for
+        // the "reverse" function existence at the analyze function.
+        unreachable!();
+    };
+    // Check if the "reverse" function contains the "input.graphemes(true).rev().collect()"
+    // solution
+    let has_optimal_solution = reverse_fn.block.stmts.iter().any(|stmt| {
+        if let syn::Stmt::Expr(syn::Expr::MethodCall(syn::ExprMethodCall {
+            method,
+            receiver,
+            ..
+        })) = stmt
+        {
+            if method != "collect" {
+                false
+            } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
+                method, receiver, ..
+            }) = receiver.as_ref()
+            {
+                if method != "rev" {
+                    false
+                } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
+                    method,
+                    receiver,
+                    args,
+                    ..
+                }) = receiver.as_ref()
+                {
+                    if method != "graphemes" {
+                        false
+                    } else if let Some(syn::punctuated::Pair::End(syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Bool(syn::LitBool { value, .. }),
+                        ..
+                    }))) = args.first()
+                    {
+                        *value
+                    } else if let syn::Expr::Path(syn::ExprPath { path, .. }) = receiver.as_ref() {
+                        if let Some(syn::punctuated::Pair::End(path_segment)) =
+                            path.segments.first()
+                        {
+                            if let Some(syn::punctuated::Pair::End(syn::FnArg::Captured(
+                                syn::ArgCaptured {
+                                    pat: syn::Pat::Ident(syn::PatIdent { ident, .. }),
+                                    ..
+                                },
+                            ))) = reverse_fn.decl.inputs.first()
+                            {
+                                *ident == path_segment.ident
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    });
+    let has_use_item = if let Some(syn::Item::Use(syn::ItemUse {
+        tree: syn::UseTree::Path(syn::UsePath { ident, tree, .. }),
+        ..
+    })) = ast.items.iter().find(|item| {
+        if let syn::Item::Use(_) = item {
+            true
+        } else {
+            false
+        }
+    }) {
+        ident == "unicode_segmentation"
+            && if let syn::UseTree::Name(syn::UseName { ident }) = tree.as_ref() {
+                ident == "UnicodeSegmentation"
+            } else {
+                false
+            }
+    } else {
+        false
+    };
+    if has_optimal_solution && has_use_item {
+        output.status = AnalysisStatus::Approve;
+    }
+    Ok(())
+}

--- a/src/analyzers/reverse_string/mod.rs
+++ b/src/analyzers/reverse_string/mod.rs
@@ -47,8 +47,81 @@ lazy_static! {
     ];
 }
 
+/// Checks if the solution AST contains the necessary function
+/// definition. For `reverse-string` this means checking if the
+/// following function is present in the AST:
+///
+/// pub fn reverse(input: &str) -> String {}
+fn solution_contains_neccesary_fn(ast: &File) -> bool {
+    let solution_fn = if let Some(syn::Item::Fn(func)) = ast.items.iter().find(|item| {
+        if let syn::Item::Fn(item_fn) = item {
+            item_fn.ident == "reverse"
+        } else {
+            false
+        }
+    }) {
+        func
+    } else {
+        return false;
+    };
+    let solution_fn_is_public = if let syn::Visibility::Public(_) = solution_fn.vis {
+        true
+    } else {
+        false
+    };
+    let solution_fn_returns_string =
+        if let syn::ReturnType::Type(_, ref return_type) = solution_fn.decl.output {
+            if let syn::Type::Path(return_type_path) = return_type.as_ref() {
+                let segments = &return_type_path.path.segments;
+                segments.len() == 1
+                    && if let Some(segment) = segments.first() {
+                        segment.value().ident == "String"
+                    } else {
+                        false
+                    }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+    let solution_fn_accepts_str =
+        if let Some(syn::punctuated::Pair::End(syn::FnArg::Captured(syn::ArgCaptured {
+            ty: syn::Type::Reference(typ),
+            ..
+        }))) = solution_fn.decl.inputs.first()
+        {
+            if let syn::Type::Path(syn::TypePath {
+                path: syn::Path { segments, .. },
+                ..
+            }) = typ.elem.as_ref()
+            {
+                if let Some(syn::punctuated::Pair::End(syn::PathSegment { ident, .. })) =
+                    segments.first()
+                {
+                    ident == "str"
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        } && solution_fn.decl.inputs.len() == 1;
+    solution_fn_is_public && solution_fn_returns_string && solution_fn_accepts_str
+}
+
 impl Analyze for ReverseStringAnalyzer {
     fn analyze(&self, solution_ast: &File) -> Result<AnalysisOutput> {
+        // Check if the 'reverse' function is present, before
+        // running any lints on the solution.
+        if !solution_contains_neccesary_fn(solution_ast) {
+            return Ok(AnalysisOutput::new(
+                AnalysisStatus::Disapprove,
+                vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+            ));
+        }
         Ok(
             if let Some(output) = PREPARED_SOLUTION_OUTPUTS
                 .iter()

--- a/src/analyzers/reverse_string/mod.rs
+++ b/src/analyzers/reverse_string/mod.rs
@@ -1,4 +1,5 @@
 pub mod comments;
+mod lints;
 #[cfg(test)]
 mod test;
 
@@ -10,223 +11,10 @@ use crate::{
     Result,
 };
 use comments::ReverseStringComment;
+use lints::REVERSE_STRING_LINTS;
 use syn::File;
 
 pub struct ReverseStringAnalyzer;
-
-type ReverseStringLint = Box<dyn Fn(&File, &mut AnalysisOutput) -> Result<()>>;
-
-/// Generates a vector of the linting functions. Each one of them accepts a reference
-/// to the solution AST and a mutable reference to the analysis output and
-/// modifies the output in accordance to the lint that they represent.
-fn generate_lints() -> Vec<ReverseStringLint> {
-    vec![
-        Box::new(|ast, output| {
-            let has_extern = ast.items.iter().any(|item| {
-                if let syn::Item::ExternCrate(_) = item {
-                    true
-                } else {
-                    false
-                }
-            });
-            if has_extern {
-                output
-                    .comments
-                    .push(ReverseStringComment::SuggestRemovingExternCrate.to_string());
-            }
-            Ok(())
-        }),
-        Box::new(|ast, output| {
-            let reverse_fn = if let Some(syn::Item::Fn(func)) = ast.items.iter().find(|item| {
-                if let syn::Item::Fn(item_fn) = item {
-                    item_fn.ident == "reverse"
-                } else {
-                    false
-                }
-            }) {
-                func
-            } else {
-                // We can use the unreachable!, since we have already check for
-                // the "reverse" function existence at the analyze function.
-                unreachable!();
-            };
-            // Check if the "reverse" function contains the "input.chars().rev().collect()"
-            // solution
-            let has_standard_solution = reverse_fn.block.stmts.iter().any(|stmt| {
-                if let syn::Stmt::Expr(syn::Expr::MethodCall(syn::ExprMethodCall {
-                    method,
-                    receiver,
-                    ..
-                })) = stmt
-                {
-                    if method != "collect" {
-                        false
-                    } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
-                        method,
-                        receiver,
-                        ..
-                    }) = receiver.as_ref()
-                    {
-                        if method != "rev" {
-                            false
-                        } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
-                            method,
-                            receiver,
-                            ..
-                        }) = receiver.as_ref()
-                        {
-                            if method != "chars" {
-                                false
-                            } else if let syn::Expr::Path(syn::ExprPath { path, .. }) =
-                                receiver.as_ref()
-                            {
-                                if let Some(syn::punctuated::Pair::End(path_segment)) =
-                                    path.segments.first()
-                                {
-                                    if let Some(syn::punctuated::Pair::End(syn::FnArg::Captured(
-                                        syn::ArgCaptured {
-                                            pat: syn::Pat::Ident(syn::PatIdent { ident, .. }),
-                                            ..
-                                        },
-                                    ))) = reverse_fn.decl.inputs.first()
-                                    {
-                                        *ident == path_segment.ident
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            });
-            if has_standard_solution {
-                output.status = AnalysisStatus::Approve;
-                output
-                    .comments
-                    .push(ReverseStringComment::SuggestDoingBonusTest.to_string())
-            }
-            Ok(())
-        }),
-        Box::new(|ast, output| {
-            let reverse_fn = if let Some(syn::Item::Fn(func)) = ast.items.iter().find(|item| {
-                if let syn::Item::Fn(item_fn) = item {
-                    item_fn.ident == "reverse"
-                } else {
-                    false
-                }
-            }) {
-                func
-            } else {
-                // We can use the unreachable!, since we have already check for
-                // the "reverse" function existence at the analyze function.
-                unreachable!();
-            };
-            // Check if the "reverse" function contains the "input.graphemes(true).rev().collect()"
-            // solution
-            let has_optimal_solution = reverse_fn.block.stmts.iter().any(|stmt| {
-                if let syn::Stmt::Expr(syn::Expr::MethodCall(syn::ExprMethodCall {
-                    method,
-                    receiver,
-                    ..
-                })) = stmt
-                {
-                    if method != "collect" {
-                        false
-                    } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
-                        method,
-                        receiver,
-                        ..
-                    }) = receiver.as_ref()
-                    {
-                        if method != "rev" {
-                            false
-                        } else if let syn::Expr::MethodCall(syn::ExprMethodCall {
-                            method,
-                            receiver,
-                            args,
-                            ..
-                        }) = receiver.as_ref()
-                        {
-                            if method != "graphemes" {
-                                false
-                            } else if let Some(syn::punctuated::Pair::End(syn::Expr::Lit(
-                                syn::ExprLit {
-                                    lit: syn::Lit::Bool(syn::LitBool { value, .. }),
-                                    ..
-                                },
-                            ))) = args.first()
-                            {
-                                *value
-                            } else if let syn::Expr::Path(syn::ExprPath { path, .. }) =
-                                receiver.as_ref()
-                            {
-                                if let Some(syn::punctuated::Pair::End(path_segment)) =
-                                    path.segments.first()
-                                {
-                                    if let Some(syn::punctuated::Pair::End(syn::FnArg::Captured(
-                                        syn::ArgCaptured {
-                                            pat: syn::Pat::Ident(syn::PatIdent { ident, .. }),
-                                            ..
-                                        },
-                                    ))) = reverse_fn.decl.inputs.first()
-                                    {
-                                        *ident == path_segment.ident
-                                    } else {
-                                        false
-                                    }
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            });
-            let has_use_item = if let Some(syn::Item::Use(syn::ItemUse {
-                tree: syn::UseTree::Path(syn::UsePath { ident, tree, .. }),
-                ..
-            })) = ast.items.iter().find(|item| {
-                if let syn::Item::Use(_) = item {
-                    true
-                } else {
-                    false
-                }
-            }) {
-                ident == "unicode_segmentation"
-                    && if let syn::UseTree::Name(syn::UseName { ident }) = tree.as_ref() {
-                        ident == "UnicodeSegmentation"
-                    } else {
-                        false
-                    }
-            } else {
-                false
-            };
-            if has_optimal_solution && has_use_item {
-                output.status = AnalysisStatus::Approve;
-            }
-            Ok(())
-        }),
-    ]
-}
 
 /// Checks if the solution AST contains the necessary function
 /// definition. For `reverse-string` this means checking if the
@@ -304,7 +92,7 @@ impl Analyze for ReverseStringAnalyzer {
             ));
         }
         let mut analysis_output = AnalysisOutput::new(AnalysisStatus::ReferToMentor, vec![]);
-        generate_lints()
+        REVERSE_STRING_LINTS
             .iter()
             .try_for_each(|lint| lint(solution_ast, &mut analysis_output))
             .map(|_| analysis_output)

--- a/src/analyzers/reverse_string/mod.rs
+++ b/src/analyzers/reverse_string/mod.rs
@@ -201,7 +201,26 @@ fn generate_lints() -> Vec<ReverseStringLint> {
                     false
                 }
             });
-            if has_optimal_solution {
+            let has_use_item = if let Some(syn::Item::Use(syn::ItemUse {
+                tree: syn::UseTree::Path(syn::UsePath { ident, tree, .. }),
+                ..
+            })) = ast.items.iter().find(|item| {
+                if let syn::Item::Use(_) = item {
+                    true
+                } else {
+                    false
+                }
+            }) {
+                ident == "unicode_segmentation"
+                    && if let syn::UseTree::Name(syn::UseName { ident }) = tree.as_ref() {
+                        ident == "UnicodeSegmentation"
+                    } else {
+                        false
+                    }
+            } else {
+                false
+            };
+            if has_optimal_solution && has_use_item {
                 output.status = AnalysisStatus::Approve;
             }
             Ok(())

--- a/src/analyzers/reverse_string/test.rs
+++ b/src/analyzers/reverse_string/test.rs
@@ -66,7 +66,7 @@ fn analyze_returns_approve_with_comment_suggest_bonus_2() {
 }
 
 #[test]
-fn analyze_returns_approve() {
+fn analyze_returns_approve_1() {
     test_analyzer_output(
         &syn::parse_str::<File>(
             "use unicode_segmentation::UnicodeSegmentation; pub fn reverse(input: &str) -> String { input.graphemes(true).rev().collect() }",
@@ -82,5 +82,55 @@ fn analyze_returns_approve_2() {
             "use unicode_segmentation::UnicodeSegmentation; pub fn reverse(input: &str) -> String { input.graphemes(true).rev().collect::<String>() }",
         ).unwrap(),
         AnalysisOutput::new(AnalysisStatus::Approve, vec![]),
+    );
+}
+
+#[test]
+fn analyze_returns_disapprove_if_no_reverse_function_is_present() {
+    test_analyzer_output(
+        &syn::parse_str::<File>("fn main() {println!(\"Test\");}").unwrap(),
+        AnalysisOutput::new(
+            AnalysisStatus::Disapprove,
+            vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+        ),
+    );
+}
+
+#[test]
+fn analyze_returns_disapprove_if_reverse_function_is_not_public() {
+    test_analyzer_output(
+        &syn::parse_str::<File>(
+            "fn reverse(input: &str) -> String { input.chars().rev().collect::<String>() }",
+        )
+        .unwrap(),
+        AnalysisOutput::new(
+            AnalysisStatus::Disapprove,
+            vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+        ),
+    );
+}
+
+#[test]
+fn analyze_returns_disapprove_if_reverse_function_does_not_return_string() {
+    test_analyzer_output(
+        &syn::parse_str::<File>("pub fn reverse(input: &str) -> &'static str { input.chars().rev().collect::<String>() }").unwrap(),
+        AnalysisOutput::new(
+            AnalysisStatus::Disapprove,
+            vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+        ),
+    );
+}
+
+#[test]
+fn analyze_returns_disapprove_if_reverse_function_does_not_accept_str() {
+    test_analyzer_output(
+        &syn::parse_str::<File>(
+            "pub fn reverse(input: String) -> String { input.chars().rev().collect::<String>() }",
+        )
+        .unwrap(),
+        AnalysisOutput::new(
+            AnalysisStatus::Disapprove,
+            vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+        ),
     );
 }

--- a/tests/analyzer.rs
+++ b/tests/analyzer.rs
@@ -95,6 +95,8 @@ analyzer_test_case!(
     )
 );
 
+//TODO: Add an integration test for the case when the reverse-string analyzer returns disapprove
+
 #[test]
 fn reverse_string_analyzer_run_on_every_solution() {
     let snippets_dir = Path::new("snippets").join("reverse-string");

--- a/tests/analyzer.rs
+++ b/tests/analyzer.rs
@@ -95,7 +95,16 @@ analyzer_test_case!(
     )
 );
 
-//TODO: Add an integration test for the case when the reverse-string analyzer returns disapprove
+analyzer_test_case!(
+    reverse_string_analyzer_writes_json_disapprove_with_solution_not_found(
+        slug = REVERSE_STRING_SLUG,
+        snippet_dir = "disapprove_with_solution_not_found",
+        expected_output = AnalysisOutput::new(
+            AnalysisStatus::Disapprove,
+            vec![ReverseStringComment::SolutionFunctionNotFound.to_string()],
+        )
+    )
+);
 
 #[test]
 fn reverse_string_analyzer_run_on_every_solution() {


### PR DESCRIPTION
This PR is an attempt at making the analyzer more flexible by replacing the 'check the solution with a number of prepared ASTs' workflow with the 'run the solution through a number of lints' workflow.
In the end it is expected to make the final analysis more thorough.

Since this PR allows more thorough analysis of the solutions it opens a possibility to use accurate comments in the result analysis. This means that the PR **will not** be merged until the necessary comments will be added to the [website-copy repository](https://github.com/exercism/website-copy).

 Closes #11
Closes #5
Contributes to #1