### PR TITLE
 reverse-string: Fixed the string representation of the reverse-string comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "rust-analyzer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-analyzer"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 description = "Exercism's automated analyzer for the Rust track."
 

--- a/src/analyzers/reverse_string/comments.rs
+++ b/src/analyzers/reverse_string/comments.rs
@@ -9,16 +9,19 @@ pub enum ReverseStringComment {
     SolutionFunctionNotFound,
 }
 
+const REVERSE_STRING_COMMENT_PREFIX: &str = "rust.reverse-string";
+
 impl Display for ReverseStringComment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ReverseStringComment::*;
         write!(
             f,
-            "{}",
+            "{}.{}",
+            REVERSE_STRING_COMMENT_PREFIX,
             match self {
-                SuggestRemovingExternCrate => "rust.reverse_string.suggest_removing_extern_crate",
-                SuggestDoingBonusTest => "rust.reverse_string.suggest_doing_bonus_test",
-                SolutionFunctionNotFound => "rust.reverse_string.solution_function_not_found",
+                SuggestRemovingExternCrate => "suggest_removing_extern_crate",
+                SuggestDoingBonusTest => "suggest_doing_bonus_test",
+                SolutionFunctionNotFound => "solution_function_not_found",
             }
         )
     }


### PR DESCRIPTION
A fix to match the string representation of the `reverse-string` comments to the contents of the [website-copy](https://github.com/exercism/website-copy/tree/master/automated-comments/rust)