### PR TITLE
Automatically push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,25 @@
+name: Push to DockerHub
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  dockerhub:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: satackey/action-docker-layer-caching@v0.0.5
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.event.repository.full_name }}
+          tag_with_sha: true
+          tags: latest
+          dockerfile: Dockerfile


### PR DESCRIPTION
The [v3 development environment](https://github.com/exercism/development-environment/) uses Docker images from Docker Hub for all the tooling.
This allows for easy testing of the various tooling components (analyzers/representer/test-runners).

This PR adds a GitHub Actions workflow to automatically build and push a new Docker image whenever something is merged to master.

See https://github.com/exercism/v3/issues/2727
