### PR TITLE
fix comments

### DIFF
--- a/src/analyzers/clock.rs
+++ b/src/analyzers/clock.rs
@@ -1,38 +1,24 @@
 use crate::prelude::*;
 
-const IMPL_DISPLAY: &str = "Nice work using `impl Display` to implement to_string.";
-
-const JUST_STORE_MINUTES: &str =
-    "(Some people don't bother storing the hours in the struct which simplifies things a bit.)";
-
-const DERIVE_PARTIAL_EQ: &str = "Equality can be derived automatically (`#[derive(PartialEq)]`).";
-const DERIVE_DEBUG: &str = "Debug can be derived automatically (`#[derive(Debug)]`).";
-
-const REM_EUCLID: &str =
-    "Alternatively to `%` and `/` you can use `rem_euclid` and `div_euclid` which \
-    [differ](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=617965fa5096580c67b809e0bc786917) \
-    when negatives are involved.";
-
-const SUGGEST_IMPL_DISPLAY: &str = "Rather than `impl ToString` \
-    it's better to `impl Display` \
-    and then we will get `to_string` for free.";
-
-const CELEBRATE_REM_EUCLID: &str = "Nice work using rem_euclid!";
-
-const IMPROVE_FORMAT_STRING: &str = "Have a look at \
-    [std::fmt](https://doc.rust-lang.org/std/fmt/#width) \
-    for a more succinct way to format the number.";
+const IMPL_DISPLAY: &str = "rust.clock.impl_display_used";
+const ONLY_STORE_MINUTES: &str = "rust.clock.only_store_minutes";
+const DERIVE_PARTIAL_EQ: &str = "rust.clock.derive_partial_eq";
+const DERIVE_DEBUG: &str = "rust.clock.derive_debug";
+const USE_REM_EUCLID: &str = "rust.clock.use_rem_euclid";
+const SUGGEST_IMPL_DISPLAY: &str = "rust.clock.use_impl_display";
+const REM_EUCLID_USED: &str = "rust.clock.rem_euclid_used";
+const IMPROVE_FORMAT_STRING: &str = "rust.clock.improve_format_string";
 
 // Order here will be order displayed in to user.
 pub static LINTS: &[Lint] = &[
     good!("Display for Clock" => IMPL_DISPLAY),
-    good!("rem_euclid" => CELEBRATE_REM_EUCLID),
+    good!("rem_euclid" => REM_EUCLID_USED),
     bad_if_missing!(":02" | ":0>2" | ":>02" => IMPROVE_FORMAT_STRING),
     bad!("Debug for Clock" => DERIVE_DEBUG),
     bad!("PartialEq for Clock" => DERIVE_PARTIAL_EQ),
     bad!("ToString for Clock" => SUGGEST_IMPL_DISPLAY),
-    note_if_missing!("rem_euclid" => REM_EUCLID),
-    note!("hours: i32," => JUST_STORE_MINUTES),
+    note_if_missing!("rem_euclid" => USE_REM_EUCLID),
+    note!("hours: i32," => ONLY_STORE_MINUTES),
 ];
 
 pub struct ClockAnalyzer;
@@ -109,8 +95,8 @@ impl Clock {
                 vec![
                     IMPL_DISPLAY.into(),
                     DERIVE_PARTIAL_EQ.into(),
-                    REM_EUCLID.to_string(),
-                    JUST_STORE_MINUTES.into(),
+                    USE_REM_EUCLID.to_string(),
+                    ONLY_STORE_MINUTES.into(),
                 ],
             ),
         );

--- a/src/analyzers/comments.rs
+++ b/src/analyzers/comments.rs
@@ -9,18 +9,19 @@ pub enum GeneralComment {
     FailedToParseSolutionFile,
 }
 
+const GENERAL_COMMENT_PREFIX: &str = "rust.general";
+
 impl Display for GeneralComment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use GeneralComment::*;
         write!(
             f,
-            "{}",
+            "{}.{}",
+            GENERAL_COMMENT_PREFIX,
             match self {
-                SolutionFileNotFound => "No lib.rs file was submitted?",
-                SolutionFunctionNotFound =>
-                    "The solution method could not be found. \
-                Have given methods been renamed?",
-                FailedToParseSolutionFile => "The solution could not be parsed.",
+                SolutionFileNotFound => "solution_file_not_found",
+                SolutionFunctionNotFound => "solution_function_not_found",
+                FailedToParseSolutionFile => "failed_to_parse_solution_file",
             }
         )
     }

--- a/src/analyzers/gigasecond.rs
+++ b/src/analyzers/gigasecond.rs
@@ -1,37 +1,29 @@
 use crate::prelude::*;
 
-const LITERALS_WITH_UNDERSCORE: &str =
-    "I like the large numeric is formatted with underscores to be more readable.";
-const PLUS_OP_USED: &str = "I like this solution directly adds `Duration` to `start` with \
-    the `+` operator.";
+const LITERAL_WITH_UNDERSCORE_USED: &str = "rust.general.literal_with_underscore_used";
+const PLUS_OP_USED: &str = "rust.gigasecond.plus_operator_used";
 
-const PREFER_LITERAL: &'static str = "Rather than using `.pow`, rust number literals can have \
-    `_` in them to make them more readable, for example: `1_000`. (This also avoids the cast)";
-const SUGGEST_ADD: &'static str = "This could be simplified to `start + Duration::seconds`.";
-const SUGGEST_OP: &'static str = "Did you know that the `+` operator works for DateTime?";
+const PREFER_LITERAL: &'static str = "rust.gigasecond.literal_instead_of_pow";
+const ADD_DURATION: &'static str = "rust.gigasecond.add_duration";
+const USE_PLUS_OP: &'static str = "rust.gigasecond.use_plus_operator";
 
-const RUST_FMT: &'static str = "A minor style point is that usually \
-    `rustfmt` will usually put `use` elements in alphabetical order. In larger programs with \
-    a lot of `use` statements it can be helpful to have them ordered alphabetically.";
-const GOOD_FOCUS_ON_OVERFLOW: &str = "Good idea considering overflow conditions by using \
-    `checked_add_signed` method of `DateTime<Utc>`.";
-const HINT_LITERAL_SEPARATERS: &str = "Did you know that rust number literals can have `_` in \
-    them to make them more readable? For example: `1_000`";
-const GOOD_NO_RETURN_STATEMENT: &str = "I like that the expression is directly returned instead \
-    of being set to a binding and returning the binding or using return and a semicolon.";
-const PERFECT: &str = "Perfect";
+const SORT_USE_ELEMENTS: &'static str = "rust.general.sort_use_elements";
+const CHECKED_OVERFLOW: &str = "rust.gigasecond.checked_overflow";
+const USE_LITERAL_WITH_UNDERSCORE: &str = "rust.general.use_literal_with_underscore";
+const DIRECT_RETURN_EXPRESSION: &str = "rust.general.direct_return_expression";
+const PERFECT: &str = "rust.general.perfect";
 
 pub static LINTS: &[Lint] = &[
-    good!("1_000_000_000" => LITERALS_WITH_UNDERSCORE),
+    good!("1_000_000_000" => LITERAL_WITH_UNDERSCORE_USED),
     good!("start +" => PLUS_OP_USED),
     good!("start + Duration::seconds(1_000_000_000)" => PERFECT),
     bad!(".pow(" => PREFER_LITERAL),
-    bad!("Utc.timestamp(" => SUGGEST_ADD),
-    bad!("start.add(" => SUGGEST_OP),
-    note!("use chrono::{DateTime, Utc, Duration};" => RUST_FMT),
-    good!("checked_add_signed" => GOOD_FOCUS_ON_OVERFLOW),
-    bad_if_missing!("_" => HINT_LITERAL_SEPARATERS),
-    good_if_missing!(";" => GOOD_NO_RETURN_STATEMENT),
+    bad!("Utc.timestamp(" => ADD_DURATION),
+    bad!("start.add(" => USE_PLUS_OP),
+    note!("use chrono::{DateTime, Utc, Duration};" => SORT_USE_ELEMENTS),
+    good!("checked_add_signed" => CHECKED_OVERFLOW),
+    bad_if_missing!("_" => USE_LITERAL_WITH_UNDERSCORE),
+    good_if_missing!(";" => DIRECT_RETURN_EXPRESSION),
 ];
 
 pub struct GigasecondAnalyzer;
@@ -72,7 +64,7 @@ pub fn after(start: DateTime<Utc>) -> DateTime<Utc> {
             AnalysisOutput::new(
                 AnalysisStatus::Approve,
                 vec![
-                    LITERALS_WITH_UNDERSCORE.to_string(),
+                    LITERAL_WITH_UNDERSCORE_USED.to_string(),
                     PLUS_OP_USED.to_string(),
                 ],
             ),


### PR DESCRIPTION
- Fix general comments
- Use ids for clock comments
- Use ids for gigasecond comments

See https://github.com/exercism/website-copy/pull/2128

Closes https://github.com/exercism/rust-analyzer/issues/36