### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 *.swp
 .git/
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 .github
 .gitignore
 .gitattributes
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 *.swp
 .git/
 .appends
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 .git/
 .appends
 .github
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 .appends
 .github
 .gitignore
+.gitattributes


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
