### PR TITLE
Fix new warnings

### DIFF
--- a/src/analyzers/gigasecond.rs
+++ b/src/analyzers/gigasecond.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 const LITERAL_WITH_UNDERSCORE_USED: &str = "rust.general.literal_with_underscore_used";
 const PLUS_OP_USED: &str = "rust.gigasecond.plus_operator_used";
 
-const PREFER_LITERAL: &'static str = "rust.gigasecond.literal_instead_of_pow";
-const ADD_DURATION: &'static str = "rust.gigasecond.add_duration";
-const USE_PLUS_OP: &'static str = "rust.gigasecond.use_plus_operator";
+const PREFER_LITERAL: &str = "rust.gigasecond.literal_instead_of_pow";
+const ADD_DURATION: &str = "rust.gigasecond.add_duration";
+const USE_PLUS_OP: &str = "rust.gigasecond.use_plus_operator";
 
-const SORT_USE_ELEMENTS: &'static str = "rust.general.sort_use_elements";
+const SORT_USE_ELEMENTS: &str = "rust.general.sort_use_elements";
 const CHECKED_OVERFLOW: &str = "rust.gigasecond.checked_overflow";
 const USE_LITERAL_WITH_UNDERSCORE: &str = "rust.general.use_literal_with_underscore";
 const DIRECT_RETURN_EXPRESSION: &str = "rust.general.direct_return_expression";

--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -93,7 +93,7 @@ pub trait Analyze {
         &self,
         method_hint: &str,
         solution_raw: &str,
-        lints: &[fn(&str) -> Option<(i32, String)>],
+        lints: &[Lint],
         pass_threshold: i32,
     ) -> Result<AnalysisOutput> {
         if !solution_raw.contains(method_hint) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub fn analyze_exercise(slug: &str, solution_dir: &str) -> Result<()> {
         )
     } else {
         let source = &fs::read_to_string(solution_file_path)?;
-        if let Ok(solution_ast) = syn::parse_file(&source) {
+        if let Ok(solution_ast) = syn::parse_file(source) {
             // Solution file exists and can be parsed by syn => run analysis
             get_analyzer(slug)?.analyze(&solution_ast, source)?
         } else {

--- a/tests/analyzer.rs
+++ b/tests/analyzer.rs
@@ -13,15 +13,19 @@ const REVERSE_STRING_SLUG: &str = "reverse-string";
 fn check_analysis_json(solution_dir_path: &Path, expected: &AnalysisOutput) {
     let analysis_json_path = solution_dir_path.join("analysis.json");
     assert!(analysis_json_path.exists());
-    let analysis_json_content = fs::read_to_string(&analysis_json_path).expect(&format!(
-        "Failed to read the analysis.json file at path {}",
-        analysis_json_path.display()
-    ));
-    let analysis_json_output: serde_json::Value = serde_json::from_str(&analysis_json_content)
-        .expect(&format!(
-            "Failed to deserialize the content of the analysis.json file at path {}",
+    let analysis_json_content = fs::read_to_string(&analysis_json_path).unwrap_or_else(|_| {
+        panic!(
+            "Failed to read the analysis.json file at path {}",
             analysis_json_path.display()
-        ));
+        )
+    });
+    let analysis_json_output: serde_json::Value = serde_json::from_str(&analysis_json_content)
+        .unwrap_or_else(|_| {
+            panic!(
+                "Failed to deserialize the content of the analysis.json file at path {}",
+                analysis_json_path.display()
+            )
+        });
     assert_eq!(
         analysis_json_output,
         serde_json::to_value(expected).unwrap()


### PR DESCRIPTION
Since the code was touched the last time, lints in the compiler and clippy have been improved. This takes care of the new warnings.