### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.42-stretch as base
+FROM rust:1.71-slim as base
 
 WORKDIR /analyzer
 


### PR DESCRIPTION
the error:
https://github.com/exercism/rust-analyzer/actions/runs/5678565525/job/15389045502

looks like debian strech is not supported anymore. updating to a recent base image fixed it for me locally.