### PR TITLE
Rewrite Dockerfile to share layers with test-runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ EOF
 # "nightly-slim", select "linux/amd64" and copy the manifest digest.
 # https://hub.docker.com/r/rustlang/rust/tags
 #
-FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c as rust-nightly-with-local-registry
+FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c AS rust-nightly-with-local-registry
 
 # add local registry
 COPY --from=build-local-registry /local-registry /local-registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,63 @@
-FROM rust:1.95-slim AS base
+############################# START SHARED LAYERS #############################
 
-WORKDIR /analyzer
+# IMPORTANT: This part of the build is shared between the test-runner and
+# analyzer. It takes a relatively large amount of space: 850 MB for the Rust
+# toolchain and 40 MB for the local cargo registry. Therefore, it's important
+# to keep this in sync between the two images. A slight mismatch in these layers
+# would lead to douple the storage requirement on Exercism's servers.
 
+FROM rust:1.95.0 AS build-local-registry
+
+WORKDIR /work
+COPY local-registry/Cargo.toml .
+
+RUN <<EOF
+set -eux
+apt-get update
+apt-get install -y gcc openssl cmake
+cargo install --locked cargo-local-registry
+cargo generate-lockfile
+cargo local-registry sync Cargo.lock /local-registry
+EOF
+
+# As of April 2026, we need to use the nightly toolchain to get JSON test output
+# tracking issue: https://github.com/rust-lang/rust/issues/49359
+#
+# The official docker image for the nightly Rust toolchain is updated every
+# day. We don't want to invalidate the build cache that often, so we pin it
+# to a specific hash. To update, go to the following page, then navigate to
+# "nightly-slim", select "linux/amd64" and copy the manifest digest.
+# https://hub.docker.com/r/rustlang/rust/tags
+#
+FROM docker.io/rustlang/rust@sha256:3444fefbb69afbff45c0722c8045404c8e7f369c5202e916bd94f665b69f1b1c as rust-nightly-with-local-registry
+
+# add local registry
+COPY --from=build-local-registry /local-registry /local-registry
+RUN <<EOF
+echo "\
+[source.crates-io]
+registry = 'sparse+https://index.crates.io/'
+replace-with = 'local-registry'
+
+[source.local-registry]
+local-registry = '/local-registry'" >> $CARGO_HOME/config.toml
+EOF
+
+############################## END SHARED LAYERS ##############################
+
+
+FROM rust:1.95.0 AS build
+
+WORKDIR /work
 COPY . .
-
 RUN cargo build --release
 
-# cargo-local-registry stuff is copied from the test runner
-FROM rust:1.95 AS build-cargo-local-registry
 
-# install cargo-local-registry
-RUN cargo install --locked cargo-local-registry
-# download popular crates to local registry
-WORKDIR /local-registry
-COPY local-registry/* ./
-RUN cargo generate-lockfile && cargo local-registry --sync Cargo.lock .
-
-FROM rust:1.95-slim
-
-WORKDIR /opt/analyzer
+FROM rust-nightly-with-local-registry
 
 RUN rustup component add clippy
 
-COPY ./bin/run.sh ./bin/
-COPY --from=base /analyzer/target/release/rust-analyzer ./bin/rust-analyzer
-COPY --from=build-cargo-local-registry /local-registry local-registry/
-# configure local-registry
-RUN echo '[source.crates-io]\n\
-    registry = "https://github.com/rust-lang/crates.io-index"\n\
-    replace-with = "local-registry"\n\
-    \n\
-    [source.local-registry]\n\
-    local-registry = "/opt/analyzer/local-registry/"\n' >> $CARGO_HOME/config.toml
-
+WORKDIR /opt/analyzer
+COPY --from=build /work/target/release/rust-analyzer bin/
+COPY bin/run.sh bin/
 ENTRYPOINT ["bin/run.sh"]

--- a/local-registry/Cargo.toml
+++ b/local-registry/Cargo.toml
@@ -1,19 +1,11 @@
-[package]
-name = "dummy_package"
-version = "0.1.0"
-edition = "2021"
-
-[lib]
-path = "dummy.rs"
-
 # IMPORTANT: These dependencies should be kept in sync with the ones at
-# https://github.com/exercism/rust-test-runner/blob/main/local-registry/Cargo.toml
+# https://github.com/exercism/rust-analyzer/blob/main/local-registry/Cargo.toml
 #
 # Some crates are used by a large number of solutions. For example, when a crate
 # is required or already included in the exercise skeleton. For those crates,
-# we should *never* drop support for a given major version. We can continue to
-# support old and new versions by giving the old ones an alias. The downside is
-# an increase in the size of the local registry.
+# we should NEVER drop support for a given major version. They have been marked
+# with a "# pin" comment. We can continue to support old and new versions by
+# giving the old ones an alias. An example is the rand_09 crate below.
 # 
 [dependencies]
 anyhow = "1.0.102" # pin
@@ -119,3 +111,13 @@ unzip-n = "0.1.4"
 uuid = "1.23.1"
 voca_rs = "1.15.2"
 xvii = "0.4.0"
+
+# The following is only needed so the Cargo.toml defines a valid package.
+
+[package]
+name = "dummy_package"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "/dev/null"

--- a/snippets/two_comments/expected_analysis.json
+++ b/snippets/two_comments/expected_analysis.json
@@ -10,7 +10,7 @@
     {
       "comment": "rust.general.clippy",
       "params": {
-        "clippy_msg": "warning: unneeded `return` statement\n --> src/lib.rs:2:5\n  |\n2 |     return --x;\n  |     ^^^^^^^^^^\n  |\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#needless_return\n  = note: `#[warn(clippy::needless_return)]` on by default\nhelp: remove `return`\n  |\n2 -     return --x;\n2 +     --x\n  |"
+        "clippy_msg": "warning: unneeded `return` statement\n --> src/lib.rs:2:5\n  |\n2 |     return --x;\n  |     ^^^^^^^^^^\n  |\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return\n  = note: `#[warn(clippy::needless_return)]` on by default\nhelp: remove `return`\n  |\n2 -     return --x;\n2 +     --x\n  |"
       },
       "type": "informative"
     }


### PR DESCRIPTION
The main goal of this is to bring the Dockerfiles of the test-runner and analyzer in sync, so they can share the big layers containing the Rust toolchain and local cargo registry.

Some incidental changes / improvements that were made:

* Use an official base image with a nightly Rust toolchain, but pinned to a specific hash. This avoids our cache being invalidated every day, without us needing to copy-paste the upstream build script. The requirement to use a nightly toolchain comes from the test runner.

* Make local-registry/Cargo.toml more readable for users by moving irrelevant stuff to the bottom. Exercises contain a link to this file, so that students can check themselves which crates are available.

The forum post discussing this:
https://forum.exercism.org/t/requesting-rust-docker-base-repository/48577