### PR TITLE
Reduce unneeded image build cache invalidation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ EOF
 FROM rust:1.95.0 AS build
 
 WORKDIR /work
-COPY . .
+COPY Cargo.* .
+COPY src src
 RUN cargo build --release
 
 


### PR DESCRIPTION
Previously, the image build would recompile the analyzer when some unrelated files were changed. By only copying the files required to build the analyzer, these unnecessary rebuilds are avoided.